### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -8,6 +8,6 @@ jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    # Only handle push events from the main branch, to decrease noise
-    # if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # Only handle push events from the main branch or tags, to decrease PR noise
+    # if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.2.0 (IN PROGRESS)
 * Use functional components instead of class components ([UIFC-362](https://folio-org.atlassian.net/browse/UIFC-362))
 * Remove dependency to stripes-acq-components, use mocks local ([UIFC-368](https://folio-org.atlassian.net/browse/UIFC-368))
+* Fix GitHub Actions workflow not running for tags ([FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086))
 
 ## [6.1.0](https://github.com/folio-org/ui-plugin-find-finc-metadata-collection/tree/v6.1.0) (2024-03-20)
 * Translation updates


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.
